### PR TITLE
fix: 댓글 양방향 관계 추가 및 삭제 시 함께 삭제 되도록 수정

### DIFF
--- a/src/main/java/com/example/sns/feed/application/CommentService.java
+++ b/src/main/java/com/example/sns/feed/application/CommentService.java
@@ -28,7 +28,7 @@ public class CommentService {
         Feed feed = getFeed(request);
 
         Comment comment = Comment.createComment(member, feed, request.getContent());
-        commentRepository.save(comment);
+        feed.addComment(comment);
     }
 
     private Feed getFeed(NewCommentRequest request) {

--- a/src/main/java/com/example/sns/feed/domain/Feed.java
+++ b/src/main/java/com/example/sns/feed/domain/Feed.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.StringUtils;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -33,8 +34,11 @@ public class Feed {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "feed")
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FeedImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.PERSIST)
+    private List<Comment> comments = new ArrayList<>();
 
     public Feed(Member member, String content) {
         this.content = content;
@@ -46,15 +50,25 @@ public class Feed {
     }
 
     public void updateFeedImage(List<FeedImage> feedImages) {
-        this.images = feedImages;
+        images.clear();
+        images.addAll(feedImages);
     }
 
     public void editFeed(String content, List<FeedImage> feedImages) {
         this.content = getEmptyStringIfContentNull(content);
-        this.images = feedImages;
+        updateFeedImage(feedImages);
+    }
+
+    public void deleteFeed() {
+        images.clear();
+        comments.clear();
     }
 
     private static String getEmptyStringIfContentNull(String content) {
         return Optional.ofNullable(content).orElse("");
+    }
+
+    public void addComment(Comment comment) {
+        comments.add(comment);
     }
 }

--- a/src/main/java/com/example/sns/feed/domain/FeedImageRepository.java
+++ b/src/main/java/com/example/sns/feed/domain/FeedImageRepository.java
@@ -1,6 +1,0 @@
-package com.example.sns.feed.domain;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface FeedImageRepository extends JpaRepository<FeedImage, Long> {
-}

--- a/src/test/java/com/example/sns/feed/application/FeedServiceTest.java
+++ b/src/test/java/com/example/sns/feed/application/FeedServiceTest.java
@@ -1,9 +1,9 @@
 package com.example.sns.feed.application;
 
-import com.example.sns.feed.application.dto.FeedUpdateRequest;
+import com.example.sns.feed.domain.Comment;
+import com.example.sns.feed.domain.CommentRepository;
 import com.example.sns.feed.domain.Feed;
 import com.example.sns.feed.domain.FeedImage;
-import com.example.sns.feed.domain.FeedImageRepository;
 import com.example.sns.feed.domain.FeedRepository;
 import com.example.sns.feed.exception.FeedNotFoundException;
 import com.example.sns.imagestore.exception.ImageStoreException;
@@ -17,10 +17,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 
+import static com.example.sns.common.fixtures.CommentFixture.getBasicComment;
+import static com.example.sns.common.fixtures.CommentFixture.getBasicCommentRequest;
 import static com.example.sns.common.fixtures.FeedFixture.BASIC_FEED_CONTENT;
 import static com.example.sns.common.fixtures.FeedFixture.BASIC_FEED_IMAGE2;
 import static com.example.sns.common.fixtures.FeedFixture.EDIT_FEED_CONTENT;
@@ -54,7 +58,13 @@ class FeedServiceTest {
     FeedRepository feedRepository;
 
     @Autowired
-    FeedImageRepository feedImageRepository;
+    EntityManager em;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    CommentService commentService;
 
     Member member;
 
@@ -75,9 +85,8 @@ class FeedServiceTest {
         feedService.uploadFeed(member.getId(), getBasicUploadRequest(), getBasicFeedImages());
 
         //then
-        List<FeedImage> feedImages = feedImageRepository.findAll();
+        List<FeedImage> feedImages = getFeedImages();
         List<Feed> feeds = feedRepository.findAll();
-
         assertSoftly(softlyAssertions -> {
             softlyAssertions.assertThat(feedImages.size()).isEqualTo(imagePaths.size());
             softlyAssertions.assertThat(feedImages.get(0).getImagePath()).isEqualTo(FEED_IMAGE_PATH1);
@@ -143,14 +152,21 @@ class FeedServiceTest {
     @DisplayName("피드를 지우면 피드가 삭제되어야 함")
     void delete() throws Exception {
         //given
-        Feed feed = feedRepository.save(new Feed(member, BASIC_FEED_CONTENT));
+        Feed feed = new Feed(member, BASIC_FEED_CONTENT);
+        feed.updateFeedImage(List.of(new FeedImage(FEED_IMAGE_PATH1, feed)));
+        feed = feedRepository.save(feed);
+        commentService.createComment(member.getId(), getBasicCommentRequest(feed.getId()));
 
         //when
         feedService.deleteFeed(member.getId(), feed.getId());
 
         //then
         List<Feed> feedList = feedRepository.findAll();
+        List<Comment> comments = commentRepository.findAll();
+        List<FeedImage> feedImages = getFeedImages();
+        assertThat(comments.size()).isEqualTo(0);
         assertThat(feedList.size()).isEqualTo(0);
+        assertThat(feedImages.size()).isEqualTo(0);
     }
 
     @Test
@@ -174,5 +190,10 @@ class FeedServiceTest {
         //when then
         assertThatThrownBy(() -> feedService.deleteFeed(member.getId(), feed.getId()))
                 .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    private List<FeedImage> getFeedImages() {
+        return em.createQuery("select fi from FeedImage fi", FeedImage.class)
+                .getResultList();
     }
 }


### PR DESCRIPTION
### 특이사항

- `Feed`에서 `FeedImage` 는 `CascadeType.ALL, orphanRemoval = true`를 주고 `Comment` 는 `cascadeType.PERSIST` 만 준 이유

`FeedImage` 는 피드와 생명 주기가 완전히 같아 `CascadeType.ALL, orphanRemoval = true`을 해줘도 되지만, `Comment`는 `Member`와도 연관관계를 가지고 있기 때문에 피드만 지웠을 때 `Member`와의 관계가 있기 때문에 삭제가 되지 않음.
그래서 `Comment`는 따로 삭제를 해줘야 함