### PR TITLE
타임라인 조회 시 게시글 이미지 N + 1 문제 해결

### DIFF
--- a/src/main/java/com/example/sns/post/application/PostQueryService.java
+++ b/src/main/java/com/example/sns/post/application/PostQueryService.java
@@ -35,7 +35,7 @@ public class PostQueryService {
     }
 
     private Post getPost(Long postId) {
-        return postRepository.findById(postId)
+        return postRepository.findByIdFetchWithImages(postId)
                 .orElseThrow(() -> new PostNotFoundException(postId));
     }
 }

--- a/src/main/java/com/example/sns/post/domain/PostRepository.java
+++ b/src/main/java/com/example/sns/post/domain/PostRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("select p from Post p " +
@@ -13,6 +15,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "where f.follower.id = :memberId order by p.createdAt desc")
     Slice<Post> findMyFeed(@Param("memberId") Long memberId, Pageable pageable);
 
-    @Query("select p from Post p order by p.createdAt desc")
+    @Query("select p from Post p join fetch p.images order by p.createdAt desc")
     Slice<Post> findRecentFeed(Pageable pageable);
+
+    @Query("select p from Post p join fetch p.images i where p.id = :postId")
+    Optional<Post> findByIdFetchWithImages(@Param("postId") Long postId);
 }

--- a/src/main/resources/scripts/sql/ddl.sql
+++ b/src/main/resources/scripts/sql/ddl.sql
@@ -26,7 +26,7 @@ CREATE TABLE `post` (
                         `id` bigint NOT NULL AUTO_INCREMENT,
                         `created_at` datetime NOT NULL,
                         `last_modified_at` datetime NOT NULL,
-                        `content` varchar(255) NOT NULL DEFAULT '',
+                        `content` text NOT NULL DEFAULT (''),
                         `member_id` bigint NOT NULL,
                         PRIMARY KEY (`id`),
                         KEY `FK83s99f4kx8oiqm3ro0sasmpww` (`member_id`),


### PR DESCRIPTION
## 구현한 내용

- 게시글 이미지 N + 1 문제 해결

수정 후 쿼리
```text
Hibernate: 
    select
        post0_.id as id1_6_0_,
        images1_.id as id1_7_1_,
        post0_.created_at as created_2_6_0_,
        post0_.last_modified_at as last_mod3_6_0_,
        post0_.member_id as member_i5_6_0_,
        post0_.content as content4_6_0_,
        images1_.image_path as image_pa2_7_1_,
        images1_.post_id as post_id3_7_1_,
        images1_.post_id as post_id3_7_0__,
        images1_.id as id1_7_0__ 
    from
        post post0_ 
    inner join
        post_image images1_ 
            on post0_.id=images1_.post_id 
    order by
        post0_.created_at desc
```

Closed #95 